### PR TITLE
Add configurable epoch

### DIFF
--- a/src/main/scala/com/softwaremill/id/IdGenerator.scala
+++ b/src/main/scala/com/softwaremill/id/IdGenerator.scala
@@ -45,7 +45,12 @@ class DefaultIdGenerator(workerId: Long = 1, datacenterId: Long = 1, epoch: Long
   *
   * Single threaded!
   */
-private[id] class IdWorker(workerId: Long, datacenterId: Long, epoch: Long, var sequence: Long = 0L) extends StrictLogging {
+private[id] class IdWorker(
+    workerId: Long, 
+    datacenterId: Long, 
+    var sequence: Long = 0L,
+    val epoch: Long = 1288834974657L,
+) extends StrictLogging {
 
   private val workerIdBits     = 5L
   private val datacenterIdBits = 5L

--- a/src/main/scala/com/softwaremill/id/IdGenerator.scala
+++ b/src/main/scala/com/softwaremill/id/IdGenerator.scala
@@ -20,8 +20,8 @@ trait IdGenerator {
   *
   * *Synchronizes* to assure thread-safety!
   */
-class DefaultIdGenerator(workerId: Long = 1, datacenterId: Long = 1) extends IdGenerator {
-  private val idWorker = new IdWorker(workerId, datacenterId)
+class DefaultIdGenerator(workerId: Long = 1, datacenterId: Long = 1, epoch: Long = 1288834974657L) extends IdGenerator {
+  private val idWorker = new IdWorker(workerId, datacenterId, epoch)
 
   def nextId(): Long = {
     synchronized {
@@ -45,8 +45,7 @@ class DefaultIdGenerator(workerId: Long = 1, datacenterId: Long = 1) extends IdG
   *
   * Single threaded!
   */
-private[id] class IdWorker(workerId: Long, datacenterId: Long, var sequence: Long = 0L) extends StrictLogging {
-  val twepoch = 1288834974657L
+private[id] class IdWorker(workerId: Long, datacenterId: Long, epoch: Long, var sequence: Long = 0L) extends StrictLogging {
 
   private val workerIdBits     = 5L
   private val datacenterIdBits = 5L
@@ -103,13 +102,13 @@ private[id] class IdWorker(workerId: Long, datacenterId: Long, var sequence: Lon
     }
 
     lastTimestamp = timestamp
-    ((timestamp - twepoch) << timestampLeftShift) |
+    ((timestamp - epoch) << timestampLeftShift) |
       (datacenterId << datacenterIdShift) |
       (workerId << workerIdShift) |
       sequence
   }
 
-  def idForTimestamp(timestamp: Long): Long = (timestamp - twepoch) << timestampLeftShift
+  def idForTimestamp(timestamp: Long): Long = (timestamp - epoch) << timestampLeftShift
 
   protected def tilNextMillis(lastTimestamp: Long): Long = {
     var timestamp = timeGen()

--- a/src/test/scala/com/softwaremill/id/DefaultIdGeneratorSpec.scala
+++ b/src/test/scala/com/softwaremill/id/DefaultIdGeneratorSpec.scala
@@ -70,7 +70,7 @@ class DefaultIdGeneratorSpec extends WordSpec with MustMatchers {
         val t = System.currentTimeMillis
         worker.timeMaker = () => t
         val id = worker.nextId
-        ((id & timestampMask) >> 22) must be(t - worker.twepoch)
+        ((id & timestampMask) >> 22) must be(t - worker.epoch)
       }
     }
 


### PR DESCRIPTION
Currently, snowflakes are generated based off of Twitter's epoch and cannot be configured.  
This is a small PR which adds an additional constructor parameter for a custom epoch, defaulting to Twitter's epoch.

