### PR TITLE
Change singleNode to lazy val in PrettyIdGenerator

### DIFF
--- a/src/main/scala/com/softwaremill/id/pretty/IdPrettyfier.scala
+++ b/src/main/scala/com/softwaremill/id/pretty/IdPrettyfier.scala
@@ -110,7 +110,7 @@ object IdPrettifier {
 }
 
 object PrettyIdGenerator {
-  val singleNode = new PrettyIdGenerator(new DefaultIdGenerator(), IdPrettifier.default)
+  lazy val singleNode = new PrettyIdGenerator(new DefaultIdGenerator(), IdPrettifier.default)
   def distributed(workerId: Long, datacenterId: Long) =
     new PrettyIdGenerator(new DefaultIdGenerator(workerId, datacenterId), IdPrettifier.default)
 }


### PR DESCRIPTION
Change `singleNode` to lazy val in `PrettyIdGenerator`. Avoid unnecessary construction and log when only call `PrettyIdGenerator.distributed`.